### PR TITLE
Added command to export table consumos to XML

### DIFF
--- a/database/export_consumos.sql
+++ b/database/export_consumos.sql
@@ -1,0 +1,1 @@
+COPY (SELECT table_to_xml('consumos', true, false, '')) to 'C:\XML\Consumos.xml';


### PR DESCRIPTION
Since I couldn't do what was first talked, I just export the table Consumos as an XML.
This feature can be enchanced in next sprint.